### PR TITLE
include path improvment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,2 @@
 [build_ext]
 libraries=sqlcipher
-include_dirs=/usr/include:/usr/include/sqlcipher
-library_dirs=/usr/lib

--- a/src/python2/backup.h
+++ b/src/python2/backup.h
@@ -25,7 +25,7 @@
 #define PYSQLITE_BACKUP_H
 #include "Python.h"
 
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 #include "connection.h"
 
 typedef struct

--- a/src/python2/connection.h
+++ b/src/python2/connection.h
@@ -30,7 +30,7 @@
 #include "cache.h"
 #include "module.h"
 
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 
 typedef struct
 {

--- a/src/python2/statement.h
+++ b/src/python2/statement.h
@@ -26,7 +26,7 @@
 #include "Python.h"
 
 #include "connection.h"
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 
 #define PYSQLITE_TOO_MUCH_SQL (-100)
 #define PYSQLITE_SQL_WRONG_TYPE (-101)

--- a/src/python2/util.h
+++ b/src/python2/util.h
@@ -25,7 +25,7 @@
 #define PYSQLITE_UTIL_H
 #include "Python.h"
 #include "pythread.h"
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 #include "connection.h"
 
 int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection);

--- a/src/python3/connection.h
+++ b/src/python3/connection.h
@@ -30,7 +30,7 @@
 #include "cache.h"
 #include "module.h"
 
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 
 typedef struct
 {

--- a/src/python3/statement.h
+++ b/src/python3/statement.h
@@ -26,7 +26,7 @@
 #include "Python.h"
 
 #include "connection.h"
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 
 #define PYSQLITE_TOO_MUCH_SQL (-100)
 #define PYSQLITE_SQL_WRONG_TYPE (-101)

--- a/src/python3/util.h
+++ b/src/python3/util.h
@@ -25,7 +25,7 @@
 #define PYSQLITE_UTIL_H
 #include "Python.h"
 #include "pythread.h"
-#include "sqlite3.h"
+#include "sqlcipher/sqlite3.h"
 #include "connection.h"
 
 int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection);


### PR DESCRIPTION
As documented on the official documentation, do not include sqlite3.h and add /usr/include/sqlcipher in the include path in setup.cfg, but rather include sqlcipher/sqlite3.h.
(from https://docs.python.org/3/distutils/setupscript.html)

Extension('foo', ['foo.c'], include_dirs=['/usr/include/X11'])

You should avoid this sort of non-portable usage if you plan to distribute your code: it’s probably better to write C code like

 #include <X11/Xlib.h>

Failure case: I use a custom compiled sqlcipher, so sqlite.h is in /usr/local/include/sqlcipher. /usr/local/include is in the default include path, but /usr/local/include/sqlcipher is not and it is not in the setup.cfg either.
Any custom location will result in a build failure, so we use the correct include form in the C files and let the OS deal with include path.