### PR TITLE
bodge to make compile on python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import Extension
 # If you need to change anything, it should be enough to change setup.cfg.
 
 PACKAGE_NAME = "pysqlcipher3"
-VERSION = '1.0.3'
+VERSION = '1.0.4'
 LONG_DESCRIPTION = \
 """Python interface to SQLCipher
 

--- a/src/python3/row.c
+++ b/src/python3/row.c
@@ -231,7 +231,7 @@ PyTypeObject pysqlite_RowType = {
         sizeof(pysqlite_Row),                           /* tp_basicsize */
         0,                                              /* tp_itemsize */
         (destructor)pysqlite_row_dealloc,               /* tp_dealloc */
-        (printfunc)NULL,                  /* tp_print */
+        0,                                              /* tp_print */
         0,                                              /* tp_getattr */
         0,                                              /* tp_setattr */
         0,                                              /* tp_reserved */

--- a/src/python3/row.c
+++ b/src/python3/row.c
@@ -179,7 +179,7 @@ PyObject* pysqlite_row_keys(pysqlite_Row* self, PyObject* args, PyObject* kwargs
 
 static int pysqlite_row_print(pysqlite_Row* self, FILE *fp, int flags)
 {
-    return (&PyTuple_Type)->tp_print(self->data, fp, flags);
+  return 0; //(&PyTuple_Type)->tp_print(self->data, fp, flags);
 }
 
 static PyObject* pysqlite_iter(pysqlite_Row* self)

--- a/src/python3/row.c
+++ b/src/python3/row.c
@@ -177,11 +177,6 @@ PyObject* pysqlite_row_keys(pysqlite_Row* self, PyObject* args, PyObject* kwargs
     return list;
 }
 
-static int pysqlite_row_print(pysqlite_Row* self, FILE *fp, int flags)
-{
-  return 0; //(&PyTuple_Type)->tp_print(self->data, fp, flags);
-}
-
 static PyObject* pysqlite_iter(pysqlite_Row* self)
 {
     return PyObject_GetIter(self->data);
@@ -236,7 +231,7 @@ PyTypeObject pysqlite_RowType = {
         sizeof(pysqlite_Row),                           /* tp_basicsize */
         0,                                              /* tp_itemsize */
         (destructor)pysqlite_row_dealloc,               /* tp_dealloc */
-        (printfunc)pysqlite_row_print,                  /* tp_print */
+        (printfunc)NULL,                  /* tp_print */
         0,                                              /* tp_getattr */
         0,                                              /* tp_setattr */
         0,                                              /* tp_reserved */


### PR DESCRIPTION
`pysqlite_row_print` is not used anywhere, so this shouldn't break anything.  