### PR TITLE
Fix error message in assertion

### DIFF
--- a/lib/test/python2/sqlcipher.py
+++ b/lib/test/python2/sqlcipher.py
@@ -97,7 +97,7 @@ class SqlCipherTests(unittest.TestCase):
             col_value = self.queryData(conn)
             self.assertIsNone(col_value)
         except sqlite.DatabaseError as ex:
-            self.assertEqual('file is encrypted or is not a database', str(ex))
+            self.assertIn('is not a database', str(ex))
         finally:
             conn.close()
 

--- a/lib/test/python3/sqlcipher.py
+++ b/lib/test/python3/sqlcipher.py
@@ -97,7 +97,7 @@ class SqlCipherTests(unittest.TestCase):
             col_value = self.queryData(conn)
             self.assertIsNone(col_value)
         except sqlite.DatabaseError as ex:
-            self.assertEqual('file is encrypted or is not a database', str(ex))
+            self.assertIn('is not a database', str(ex))
         finally:
             conn.close()
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import Extension
 # If you need to change anything, it should be enough to change setup.cfg.
 
 PACKAGE_NAME = "pysqlcipher3"
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 LONG_DESCRIPTION = \
 """Python interface to SQLCipher
 


### PR DESCRIPTION
Due to error text adjustment of sqlcipher repository https://github.com/sqlcipher/sqlcipher/commit/821782a23b06ab2fd774ae2500d18e1cc2a82a80

Through running pysqlcipher3 I never get the `file is encrypted or is not a database` message.
Only get `file is not a database` message, so I was studying some reported Issues and the [third point in this comment](https://github.com/rigglemania/pysqlcipher3/pull/13#issuecomment-423777248).
So I think this modification fixes 4 failures and only 2 errors remain when running `python setup.py test` provided using Python3.X (I used Python 3.9.6 on an Mac OS X 11.4 system)