### PR TITLE
Make it work with python 3.11

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,13 @@
 =======================
 Changes in pysqlcipher3
 =======================
+Release 1.2.0
+-------------
+* Add support for Python 3.11
+
+Release 1.1.0
+-------------
+* Add support for Python 3.10
 
 Release 1.0.2
 -------------

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import Extension
 # If you need to change anything, it should be enough to change setup.cfg.
 
 PACKAGE_NAME = "pysqlcipher3"
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 LONG_DESCRIPTION = \
 """Python interface to SQLCipher
 

--- a/src/python3/prepare_protocol.c
+++ b/src/python3/prepare_protocol.c
@@ -78,6 +78,6 @@ PyTypeObject pysqlite_PrepareProtocolType= {
 extern int pysqlite_prepare_protocol_setup_types(void)
 {
     pysqlite_PrepareProtocolType.tp_new = PyType_GenericNew;
-    Py_TYPE(&pysqlite_PrepareProtocolType)= &PyType_Type;
+    Py_SET_TYPE(&pysqlite_PrepareProtocolType, &PyType_Type);
     return PyType_Ready(&pysqlite_PrepareProtocolType);
 }

--- a/src/python3/prepare_protocol.h
+++ b/src/python3/prepare_protocol.h
@@ -39,3 +39,10 @@ int pysqlite_prepare_protocol_setup_types(void);
 
 #define UNKNOWN (-1)
 #endif
+
+// In python >=3.11 Py_TYPE has changed https://docs.python.org/3.11/whatsnew/3.11.html
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{ ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif


### PR DESCRIPTION
In python 3.11 Py_TYPE is changed to an inline static function and now Py_SET_TYPE has to be used. Enabled backwards compatibility as stated in the release notes.